### PR TITLE
Including support for PHP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,20 @@ RUN mkdir /home/rjar/kafka \
     && tar -xvzf kafka.tgz
 RUN export GOPATH=$HOME/work
 RUN export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+RUN export DEBIAN_FRONTEND=noninteractive
+RUN export DEBCONF_NONINTERACTIVE_SEEN=true
+## preesed tzdata
+RUN echo "tzdata tzdata/Areas select Europe" > /tmp/preseed.txt; \
+    echo "tzdata tzdata/Zones/Europe select Madrid" >> /tmp/preseed.txt; \
+    debconf-set-selections /tmp/preseed.txt && \
+    apt-get update && \
+    apt-get install -y tzdata
+RUN apt -y install apache2
+RUN apt -qq -y install php libapache2-mod-php
+RUN mv -f /home/rjar/web/ports.conf /etc/apache2/ports.conf
+RUN mv -f /home/rjar/web/apache2.conf /etc/apache2/apache2.conf
+RUN mv -f /home/rjar/web/php/* /var/www/html
+RUN mv /var/www/html/index.html /var/www/html/index.html.bck
 EXPOSE 4000
+EXPOSE 8080
 CMD ./home/rjar/start-postback-in-image.sh

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ When the image is built, you can work there:
 
 ```bash
 #Running a container of postback-delivery for working on it
-docker run -it --entrypoint bash postback-delivery
+docker run -it -p 4000:4000 -p 8080:8080 --entrypoint bash postback-delivery
 #Start the app
 ./home/rjar/start-postback-in-image
 ```
@@ -58,9 +58,9 @@ Or you can run a postback-delivery based container to use it from your host:
 
 ```bash
 #To see the output of the app (Preferred for troubleshooting and also demo)
-docker run -p 4000:4000 postback-delivery
+docker run -p 4000:4000 -p 8080:8080 postback-delivery
 #In background mode
-docker run -d -p 4000:4000 postback-delivery
+docker run -d -p 4000:4000 -p 8080:8080 postback-delivery
 ```
 
 Once you are here, POST localhost:4000/postback endpoint can be used to produce messages to kafka. See [postman/delivery-postback.postman_collection.json]

--- a/start-postback-in-image.sh
+++ b/start-postback-in-image.sh
@@ -1,5 +1,5 @@
-source ~/.profile
 cd /home/rjar/
+service apache2 start
 /home/rjar/kafka/kafka_2.12-2.6.0/bin/zookeeper-server-start.sh /home/rjar/kafka/kafka_2.12-2.6.0/config/zookeeper.properties > /home/rjar/kafka/kafka_2.12-2.6.0/zookeper.log 2>&1&
 /home/rjar/kafka/kafka_2.12-2.6.0/bin/kafka-server-start.sh /home/rjar/kafka/kafka_2.12-2.6.0/config/server.properties > /home/rjar/kafka/kafka_2.12-2.6.0/kafka.log 2>&1&
 /usr/local/go/bin/go run github.com/rjar2020/post-delivery

--- a/web/apache2.conf
+++ b/web/apache2.conf
@@ -1,0 +1,232 @@
+# This is the main Apache server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See http://httpd.apache.org/docs/2.4/ for detailed information about
+# the directives and /usr/share/doc/apache2/README.Debian about Debian specific
+# hints.
+#
+#
+# Summary of how the Apache 2 configuration works in Debian:
+# The Apache 2 web server configuration in Debian is quite different to
+# upstream's suggested way to configure the web server. This is because Debian's
+# default Apache2 installation attempts to make adding and removing modules,
+# virtual hosts, and extra configuration directives as flexible as possible, in
+# order to make automating the changes and administering the server as easy as
+# possible.
+
+# It is split into several files forming the configuration hierarchy outlined
+# below, all located in the /etc/apache2/ directory:
+#
+#       /etc/apache2/
+#       |-- apache2.conf
+#       |       `--  ports.conf
+#       |-- mods-enabled
+#       |       |-- *.load
+#       |       `-- *.conf
+#       |-- conf-enabled
+#       |       `-- *.conf
+#       `-- sites-enabled
+#               `-- *.conf
+#
+#
+# * apache2.conf is the main configuration file (this file). It puts the pieces
+#   together by including all remaining configuration files when starting up the
+#   web server.
+#
+# * ports.conf is always included from the main configuration file. It is
+#   supposed to determine listening ports for incoming connections which can be
+#   customized anytime.
+#
+# * Configuration files in the mods-enabled/, conf-enabled/ and sites-enabled/
+#   directories contain particular configuration snippets which manage modules,
+#   global configuration fragments, or virtual host configurations,
+#   respectively.
+#
+#   They are activated by symlinking available configuration files from their
+#   respective *-available/ counterparts. These should be managed by using our
+#   helpers a2enmod/a2dismod, a2ensite/a2dissite and a2enconf/a2disconf. See
+#   their respective man pages for detailed information.
+#
+# * The binary is called apache2. Due to the use of environment variables, in
+#   the default configuration, apache2 needs to be started/stopped with
+#   /etc/init.d/apache2 or apache2ctl. Calling /usr/bin/apache2 directly will not
+#   work with the default configuration.
+
+
+# Global configuration
+#
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# NOTE!  If you intend to place this on an NFS (or otherwise network)
+# mounted filesystem then please read the Mutex documentation (available
+# at <URL:http://httpd.apache.org/docs/2.4/mod/core.html#mutex>);
+# you will save yourself a lot of trouble.
+#
+# Do NOT add a slash at the end of the directory path.
+#
+#ServerRoot "/etc/apache2"
+
+#
+# The accept serialization lock file MUST BE STORED ON A LOCAL DISK.
+#
+#Mutex file:${APACHE_LOCK_DIR} default
+
+#
+# The directory where shm and other runtime files will be stored.
+#
+
+DefaultRuntimeDir ${APACHE_RUN_DIR}
+
+#
+# PidFile: The file in which the server should record its process
+# identification number when it starts.
+# This needs to be set in /etc/apache2/envvars
+#
+PidFile ${APACHE_PID_FILE}
+
+#
+# Timeout: The number of seconds before receives and sends time out.
+#
+Timeout 300
+
+#
+# KeepAlive: Whether or not to allow persistent connections (more than
+# one request per connection). Set to "Off" to deactivate.
+#
+KeepAlive On
+
+#
+# MaxKeepAliveRequests: The maximum number of requests to allow
+# during a persistent connection. Set to 0 to allow an unlimited amount.
+# We recommend you leave this number high, for maximum performance.
+#
+MaxKeepAliveRequests 100
+
+#
+# KeepAliveTimeout: Number of seconds to wait for the next request from the
+# same client on the same connection.
+#
+KeepAliveTimeout 5
+
+
+# These need to be set in /etc/apache2/envvars
+User ${APACHE_RUN_USER}
+Group ${APACHE_RUN_GROUP}
+
+#
+# HostnameLookups: Log the names of clients or just their IP addresses
+# e.g., www.apache.org (on) or 204.62.129.132 (off).
+# The default is off because it'd be overall better for the net if people
+# had to knowingly turn this feature on, since enabling it means that
+# each client request will result in AT LEAST one lookup request to the
+# nameserver.
+#
+HostnameLookups Off
+
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog ${APACHE_LOG_DIR}/error.log
+
+#
+# LogLevel: Control the severity of messages logged to the error_log.
+# Available values: trace8, ..., trace1, debug, info, notice, warn,
+# error, crit, alert, emerg.
+# It is also possible to configure the log level for particular modules, e.g.
+# "LogLevel info ssl:warn"
+#
+LogLevel warn
+
+# Include module configuration:
+IncludeOptional mods-enabled/*.load
+IncludeOptional mods-enabled/*.conf
+
+# Include list of ports to listen on
+Include ports.conf
+
+
+# Sets the default security model of the Apache2 HTTPD server. It does
+# not allow access to the root filesystem outside of /usr/share and /var/www.
+# The former is used by web applications packaged in Debian,
+# the latter may be used for local directories served by the web server. If
+# your system is serving content from a sub-directory in /srv you must allow
+# access here, or in any related virtual host.
+<Directory />
+        Options FollowSymLinks
+        AllowOverride None
+        Require all denied
+</Directory>
+
+<Directory /usr/share>
+        AllowOverride None
+        Require all granted
+</Directory>
+
+<Directory /var/www/>
+        Options Indexes FollowSymLinks
+        AllowOverride None
+        Require all granted
+</Directory>
+
+#<Directory /srv/>
+#       Options Indexes FollowSymLinks
+#       AllowOverride None
+#       Require all granted
+#</Directory>
+
+
+
+
+# AccessFileName: The name of the file to look for in each directory
+# for additional configuration directives.  See also the AllowOverride
+# directive.
+#
+AccessFileName .htaccess
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being
+# viewed by Web clients.
+#
+<FilesMatch "^\.ht">
+        Require all denied
+</FilesMatch>
+
+
+#
+# The following directives define some format nicknames for use with
+# a CustomLog directive.
+#
+# These deviate from the Common Log Format definitions in that they use %O
+# (the actual bytes sent including headers) instead of %b (the size of the
+# requested file), because the latter makes it impossible to detect partial
+# requests.
+#
+# Note that the use of %{X-Forwarded-For}i instead of %h is not recommended.
+# Use mod_remoteip instead.
+#
+LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %O" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+
+# Include of directories ignores editors' and dpkg's backup files,
+# see README.Debian for details.
+
+# Include generic snippets of statements
+IncludeOptional conf-enabled/*.conf
+
+# Include the virtual host configurations:
+IncludeOptional sites-enabled/*.conf
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet
+ServerName localhost
+
+<FilesMatch \.php$>
+        SetHandler application/x-httpd-php
+</FilesMatch>

--- a/web/php/assets/styles.css
+++ b/web/php/assets/styles.css
@@ -1,0 +1,13 @@
+* { padding: 0; margin: 0; font-family: sans-serif;  font-size: 18px;  color: #f9f9f9; background: #888; -webkit-box-sizing: border-box;    -moz-box-sizing: border-box; box-sizing: border-box;}
+h2 { text-align: center; font-size: 30px;  padding-top: 50px;  }
+body { padding-top: 20px; }
+div { margin: 0 0 20px 0; }
+label { float: left; display: block; width: 200px; text-align: right; padding-right: 20px; }
+input, textarea, select { width: 400px; border: solid 3px #555; padding: 5px; background: #F9F9F9; color: #555; }
+input[type=submit] { background: #555; border: solid 5px #333; color: #F9F9F9; padding: 5px;  }
+img { height: 150px; float: left; }
+
+#Body { width: 700px; margin: 0 auto; }
+#Header { text-align: center; padding: 0 0 20px 0; width: 500px; overflow: hidden; margin: 0 auto;   }
+.multiple input { width: auto; margin: 0 15px 0 5px; }
+.multiple { font-size: 14px; }

--- a/web/php/final.php
+++ b/web/php/final.php
@@ -1,0 +1,57 @@
+<?php
+echo "<pre>";
+echo "The following postback has been delivered:";
+echo "<br>";
+echo "</pre>";
+echo pretty_print($_POST['payload']);
+
+function pretty_print($json_data)
+{
+
+$space = 0;
+$flag = false;
+
+echo "<pre>";
+
+for($counter=0; $counter<strlen($json_data); $counter++)
+{
+
+if ( $json_data[$counter] == '}' || $json_data[$counter] == ']' )
+{
+$space--;
+echo "\n";
+echo str_repeat(' ', ($space*2));
+}
+
+if ( $json_data[$counter] == '"' && ($json_data[$counter-1] == ',' ||
+$json_data[$counter-2] == ',') )
+{
+echo "\n";
+echo str_repeat(' ', ($space*2));
+}
+if ( $json_data[$counter] == '"' && !$flag )
+{
+if ( $json_data[$counter-1] == ':' || $json_data[$counter-2] == ':' )
+
+echo '<span style="color:blue;font-weight:bold">';
+else
+
+echo '<span style="color:red;">';
+}
+echo $json_data[$counter];
+
+if ( $json_data[$counter] == '"' && $flag )
+echo '</span>';
+if ( $json_data[$counter] == '"' )
+$flag = !$flag;
+
+if ( $json_data[$counter] == '{' || $json_data[$counter] == '[' )
+{
+$space++;
+echo "\n";
+echo str_repeat(' ', ($space*2));
+}
+}
+echo "</pre>";
+}
+?>

--- a/web/php/index.php
+++ b/web/php/index.php
@@ -1,0 +1,42 @@
+<?php
+
+if(count($_POST) > 0)
+{
+    if($_POST['payload'] != '')
+    {
+        header('Location: final.php');
+    }
+    else
+    {
+		$payloadError = 'validation';
+    }
+}
+
+
+?>
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Postback Form</title>
+		<link href="assets/styles.css" rel="stylesheet" type="text/css" />
+    </head>
+    <body>
+		<div id="Header">
+			<h2>
+				Postback Form
+			</h2>
+		</div>        
+        <div id="Body">
+            <form method="post" action="final.php" >	
+                <div class="<?=$payloadError?>">
+                    <label>Payload:</label>
+                    <textarea name="payload"></textarea>
+                </div>
+                <div class="multiple">
+                    <label>&nbsp;</label>
+                    <input type="submit" name="submit" value="Deliver">
+                </div>
+            </form>
+        </div>
+	</body>
+</html>

--- a/web/ports.conf
+++ b/web/ports.conf
@@ -1,0 +1,15 @@
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default.conf
+
+Listen 8080
+
+<IfModule ssl_module>
+        Listen 443
+</IfModule>
+
+<IfModule mod_gnutls.c>
+        Listen 443
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
- Include PHP infrastructure
- Include basic ingester form for calling go endpoint that publishes messages in kafka.
- PHP ingester form is accesible in localhost:8080 from local (host) machine.