### PR TITLE
Error handling refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,6 @@ Once this is exectuted the state persisted in kafka is gone.
 - Include slim dockerfile for local PHP related components and start it in docker compose along the other infra components.
 - Nice to have: multiple kafka brokers in local docker compose
 ```
-- There are a few if err != nil {} else {} statements that lead to unnecessary indentation also subscribeAndRunConsumer, always early-out with an error if you have one to clean up the code.
-```
-- Refactor error handling
-```
 - There is a certificate missing to be able to run locally (./resources/my_Cert.crt)
 ```
 - Generate image out of the VPN without needing the certs (A nice to have as apparently, as according to the feedback the Ubuntu image wasn't that important)

--- a/controller/postback.go
+++ b/controller/postback.go
@@ -20,33 +20,36 @@ type postbackController struct {
 }
 
 func (pc postbackController) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/postback" {
-		switch r.Method {
-		case http.MethodPost:
-			log.Printf("New postback received")
-			pb, err := pc.parseRequest(r)
-			if err != nil {
-				processBadRequest(w)
-				return
-			}
-			log.Printf("Request: %#v", pb)
-			jsonData, err := json.Marshal(pb)
-			if err != nil {
-				processBadRequest(w)
-				return
-			}
-			err = producer.Produce(string(jsonData), os.Getenv(env.KafkaPostBackTopic))
-			if err != nil {
-				processBadRequest(w)
-				return
-			}
-			w.Write([]byte("Postback delivered"))
-			w.WriteHeader(http.StatusCreated)
-		default:
-			w.WriteHeader(http.StatusNotImplemented)
-		}
-	} else {
+	if r.URL.Path != "/postback" {
 		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	switch r.Method {
+	case http.MethodPost:
+		log.Printf("New postback received")
+		pb, err := pc.parseRequest(r)
+		if err != nil {
+			log.Printf("Could not parse postback request %#v", err)
+			processBadRequest(w)
+			return
+		}
+		log.Printf("Request: %#v", pb)
+		jsonData, err := json.Marshal(pb)
+		if err != nil {
+			log.Printf("Could not parse postback object %#v", err)
+			processBadRequest(w)
+			return
+		}
+		err = producer.Produce(string(jsonData), os.Getenv(env.KafkaPostBackTopic))
+		if err != nil {
+			log.Printf("Could not send/produce postback message %#v", err)
+			processBadRequest(w)
+			return
+		}
+		w.Write([]byte("Postback delivered"))
+		w.WriteHeader(http.StatusCreated)
+	default:
+		w.WriteHeader(http.StatusNotImplemented)
 	}
 }
 
@@ -57,25 +60,20 @@ func newPostbackController() *postbackController {
 }
 
 func (pc postbackController) parseRequest(r *http.Request) (model.PostBack, error) {
+	var pb model.PostBack
 	buf, bodyErr := ioutil.ReadAll(r.Body)
 	if bodyErr != nil {
 		log.Print("bodyErr ", bodyErr.Error())
+		return pb, bodyErr
 	}
 	rdr1 := ioutil.NopCloser(bytes.NewBuffer(buf))
 	log.Printf("BODY: %q", rdr1)
 	dec := json.NewDecoder(rdr1)
-	var pb model.PostBack
 	err := dec.Decode(&pb)
-	if err != nil {
-		log.Printf("Could not parse postback object %#v", err)
-		return model.PostBack{}, err
-	}
-	return pb, nil
+	return pb, err
 }
 
 func processBadRequest(w http.ResponseWriter) {
-	message := "Could not parse postback object"
 	w.WriteHeader(http.StatusBadRequest)
-	w.Write([]byte(message))
-	log.Printf(message)
+	w.Write([]byte("Could not parse postback object"))
 }

--- a/model/postback.go
+++ b/model/postback.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"encoding/json"
-	"log"
 )
 
 //PostBack maps a postback message comming from the ingestors
@@ -15,8 +14,5 @@ type PostBack struct {
 func FromJSONtoPostback(payload []byte) (PostBack, error) {
 	var postBack PostBack
 	err := json.Unmarshal(payload, &postBack)
-	if err != nil {
-		log.Printf("Error decoding kafka message: %s", err)
-	}
 	return postBack, err
 }


### PR DESCRIPTION
- There are a few if err != nil {} else {} statements that lead to unnecessary indentation also subscribeAndRunConsumer, always early-out with an error if you have one to clean up the code.
```
- Refactor error handling
```